### PR TITLE
King5ive Interactive Cover

### DIFF
--- a/cover/cover.gd
+++ b/cover/cover.gd
@@ -1,0 +1,22 @@
+#Kernighan Mitchell
+
+extends Node3D
+
+@export var health: float
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+func hit(body: Node3D) -> void: 
+	print("cover hit")
+	body.queue_free()
+	health -= 1
+	print(health)
+	if(health <= 0):
+		self.queue_free()

--- a/cover/cover.gd.uid
+++ b/cover/cover.gd.uid
@@ -1,0 +1,1 @@
+uid://cb3yu5tln4q1x

--- a/cover/cover_1.tscn
+++ b/cover/cover_1.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://c8a3ul47e6b2y"]
+
+[ext_resource type="PackedScene" uid="uid://o72hyyjcmpll" path="res://cover/cover_base.tscn" id="1_tjdp8"]
+[ext_resource type="Texture2D" uid="uid://d3sodqao5sedc" path="res://temp_art/gartic/rock.png" id="2_4f4eh"]
+
+[node name="Cover" instance=ExtResource("1_tjdp8")]
+health = 5.0
+
+[node name="CollisionShape3D" parent="." index="0"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.024841309, 0, 0)
+
+[node name="Sprite3D" parent="." index="1"]
+transform = Transform3D(0.5, 0, 0, 0, 0.4330127, 0.25, 0, -0.25, 0.4330127, 0, 0.4774043, 0)
+texture = ExtResource("2_4f4eh")

--- a/cover/cover_2.tscn
+++ b/cover/cover_2.tscn
@@ -7,5 +7,5 @@
 health = 2.0
 
 [node name="Sprite3D" parent="." index="1"]
-transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)
+transform = Transform3D(0.5, 0, 0, 0, 0.4330127, 0.25, 0, -0.25, 0.4330127, 0, 0, 0)
 texture = ExtResource("2_17yxj")

--- a/cover/cover_2.tscn
+++ b/cover/cover_2.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=3 uid="uid://c2bxn6p802s68"]
+
+[ext_resource type="PackedScene" uid="uid://o72hyyjcmpll" path="res://cover/cover_base.tscn" id="1_yxvnf"]
+[ext_resource type="Texture2D" uid="uid://bimo7yhk4jp3h" path="res://temp_art/gartic/shopping_cart_of_water.png" id="2_17yxj"]
+
+[node name="Cover" instance=ExtResource("1_yxvnf")]
+health = 2.0
+
+[node name="Sprite3D" parent="." index="1"]
+transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)
+texture = ExtResource("2_17yxj")

--- a/cover/cover_base.tscn
+++ b/cover/cover_base.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3 uid="uid://o72hyyjcmpll"]
+
+[ext_resource type="Script" uid="uid://cb3yu5tln4q1x" path="res://cover/cover.gd" id="1_wykub"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_wykub"]
+size = Vector3(2.2208252, 1, 1)
+
+[node name="Cover" type="StaticBody3D"]
+script = ExtResource("1_wykub")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape3D_wykub")
+
+[node name="Sprite3D" type="Sprite3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.8660254, 0.5, 0, -0.5, 0.8660254, 0, 0, 0)

--- a/temp_art/gartic/rock.png.import
+++ b/temp_art/gartic/rock.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d3sodqao5sedc"
-path="res://.godot/imported/rock.png-065bc9ab8c93dccd30dc9fee60da2fb9.ctex"
+path.s3tc="res://.godot/imported/rock.png-065bc9ab8c93dccd30dc9fee60da2fb9.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://temp_art/gartic/rock.png"
-dest_files=["res://.godot/imported/rock.png-065bc9ab8c93dccd30dc9fee60da2fb9.ctex"]
+dest_files=["res://.godot/imported/rock.png-065bc9ab8c93dccd30dc9fee60da2fb9.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0
@@ -23,7 +24,7 @@ compress/rdo_quality_loss=0.0
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -37,4 +38,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0

--- a/temp_art/gartic/shopping_cart_of_water.png.import
+++ b/temp_art/gartic/shopping_cart_of_water.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bimo7yhk4jp3h"
-path="res://.godot/imported/shopping_cart_of_water.png-a8699a424b436cbfc0d622162193f8f8.ctex"
+path.s3tc="res://.godot/imported/shopping_cart_of_water.png-a8699a424b436cbfc0d622162193f8f8.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://temp_art/gartic/shopping_cart_of_water.png"
-dest_files=["res://.godot/imported/shopping_cart_of_water.png-a8699a424b436cbfc0d622162193f8f8.ctex"]
+dest_files=["res://.godot/imported/shopping_cart_of_water.png-a8699a424b436cbfc0d622162193f8f8.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0
@@ -23,7 +24,7 @@ compress/rdo_quality_loss=0.0
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -37,4 +38,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0

--- a/test_scenes/demo1/demo_a.tscn
+++ b/test_scenes/demo1/demo_a.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://btuw2i28k0axl"]
+[gd_scene load_steps=7 format=3 uid="uid://btuw2i28k0axl"]
 
 [ext_resource type="PackedScene" uid="uid://bk60c4813t663" path="res://world/levels/level_base.tscn" id="1_p0tjl"]
 [ext_resource type="Texture2D" uid="uid://cjbsq7rk6r3h4" path="res://temp_art/gartic/cactus.png" id="2_yl5fl"]
+[ext_resource type="PackedScene" uid="uid://c8a3ul47e6b2y" path="res://cover/cover_1.tscn" id="4_hxoc3"]
 [ext_resource type="PackedScene" uid="uid://rberd5xw8srm" path="res://world/transitions/transition.tscn" id="4_yl5fl"]
+[ext_resource type="PackedScene" uid="uid://c2bxn6p802s68" path="res://cover/cover_2.tscn" id="5_lkd7d"]
 
 [sub_resource type="Curve3D" id="Curve3D_lkd7d"]
 closed = true
@@ -39,3 +41,9 @@ target_entry_point = "Left"
 
 [node name="Right" type="Marker3D" parent="EntryPoints" index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16.214909, 0, 0.96318436)
+
+[node name="Cover" parent="." index="5" instance=ExtResource("4_hxoc3")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5492904, 0.6311088, 2.9135442)
+
+[node name="Cover2" parent="." index="6" instance=ExtResource("5_lkd7d")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.76658, 0.69281995, 3.6724815)


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #267 

**Summarize what's new, especially anything not mentioned in the issue.**
Adds a base cover class and two cover objects. Cover can be damaged and destroyed by player's bullet.

**If there's any remaining work needed, describe that here.**
Change to correct sprites

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
In demo_a shoot at rock and shopping cart