### PR TITLE
Roll stamina, Combat Encounter mode, HUD foundations

### DIFF
--- a/world/player/HUD/hud.gd
+++ b/world/player/HUD/hud.gd
@@ -1,0 +1,27 @@
+extends Control
+
+# This is the HUD. It will eventually tell the player everything about:
+# - HP (Hearts)
+# - Ammo
+# - Stamina
+# - Boss health bars
+# It's a child of the Player so that it can quickly update the HUD. 
+# For getting non-players to talk to the HUD, give the non-player object a signal and connect it to the HUD.
+
+@export var stamina_bar: ProgressBar ## The stamina bar itself, which Player tells the stamina value.
+@export var stamina_container: PanelContainer ## The stamina bar's parent that fades in and out.
+
+func _ready() -> void:
+	# Stamina bar is hidden by default until player enters a Combat Encounter.
+	$StaminaContainer.modulate.a = 0.0
+
+func fade_stamina_out() -> void:
+	var tween: Tween = get_tree().create_tween()
+	tween.tween_property(stamina_container, "modulate:a", 0.0, 0.1)
+
+func fade_stamina_in() -> void:
+	var tween: Tween = get_tree().create_tween()
+	tween.tween_property(stamina_container, "modulate:a", 1.0, 0.1)
+
+func update_stamina_bar(amount: float) -> void:
+	stamina_bar.value = amount

--- a/world/player/HUD/hud.gd.uid
+++ b/world/player/HUD/hud.gd.uid
@@ -1,0 +1,1 @@
+uid://c2rh58lkl0gwo

--- a/world/player/HUD/hud.tscn
+++ b/world/player/HUD/hud.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=3 format=3 uid="uid://bas8xwk5nhlq0"]
+
+[ext_resource type="Texture2D" uid="uid://bwm425xkr0vcy" path="res://temp_art/icon.svg" id="1_2msmg"]
+[ext_resource type="Script" uid="uid://c2rh58lkl0gwo" path="res://world/player/HUD/hud.gd" id="1_cuqld"]
+
+[node name="Hud" type="Control" node_paths=PackedStringArray("stamina_bar", "stamina_container")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_cuqld")
+stamina_bar = NodePath("StaminaContainer/ProgressBar")
+stamina_container = NodePath("StaminaContainer")
+
+[node name="StaminaContainer" type="PanelContainer" parent="."]
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -229.0
+offset_top = -114.0
+offset_right = 229.0
+offset_bottom = -84.0
+grow_horizontal = 2
+grow_vertical = 0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="StaminaContainer"]
+layout_mode = 2
+theme_override_constants/separation = 0
+alignment = 1
+
+[node name="TextureRect" type="TextureRect" parent="StaminaContainer/HBoxContainer"]
+modulate = Color(3.8789892, 3.8789892, 3.8789892, 1)
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_2msmg")
+expand_mode = 1
+
+[node name="TextureRect2" type="TextureRect" parent="StaminaContainer/HBoxContainer"]
+modulate = Color(3.8789892, 3.8789892, 3.8789892, 1)
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_2msmg")
+expand_mode = 1
+
+[node name="TextureRect3" type="TextureRect" parent="StaminaContainer/HBoxContainer"]
+modulate = Color(3.8789892, 3.8789892, 3.8789892, 1)
+layout_mode = 2
+size_flags_horizontal = 3
+texture = ExtResource("1_2msmg")
+expand_mode = 1
+
+[node name="ProgressBar" type="ProgressBar" parent="StaminaContainer"]
+layout_mode = 2
+size_flags_vertical = 1
+max_value = 3.0
+value = 3.0
+show_percentage = false

--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -8,6 +8,15 @@ static var instance:Player
 @export var roll_speed: float = 18.0
 @export var roll_duration: float = 0.4
 @export var roll_influence: float = 8 ## Controls how much player input affects steering when mid-roll. 
+var previous_facing_direction: Vector2 = Vector2.RIGHT ## Roll this way if you roll while not holding any directions. Updated every time the player makes a movement input.
+
+## Is the player currently in combat? If so, HUD will be shown and dashing will cost stamina.
+var is_in_combat: bool = false
+
+## Stamina. Consumed by rolling. Up to 3. We use a float so we can smoothly recharge it partially over time.
+var stamina: float = 3.0
+## How much stamina recharges every second. It should take 1.5 seconds for 1 bar to recover.
+const STAMINA_RECHARGE_RATE: float = 0.666667
 
 ## These are the states that the player can be in. States control what the player can do.
 enum PlayerState {
@@ -20,6 +29,10 @@ var current_state: PlayerState = PlayerState.WALKING
 ## Returns the inputted walking direction on the XZ plane (Y = 0)
 func walking_dir() -> Vector3:
 	var input := Input.get_vector("move_left", "move_right", "move_up", "move_down")
+	# We always save the last real direction (non-zero vector) the player gave as a failsafe for rolling. 
+	if input!=Vector2.ZERO: previous_facing_direction = input
+	# If the player is rolling but didn't hit a direction, let's make sure they go somewhere. Without this and the previous check, rolling without input would freeze you.
+	if input == Vector2.ZERO && current_state == PlayerState.ROLLING: input = previous_facing_direction
 	return Vector3(input.x, 0, input.y)
 
 ## Returns the direction from the player to the reticle (Y = 0)
@@ -29,11 +42,12 @@ func aim_dir() -> Vector3:
 	return dir.normalized()
 
 func _ready() -> void:
-	print("player ready")
+	print("player ready - PRESS TAB TO TEST COMBAT ENCOUNTER MODE")
 	instance = self
 
 func _init() -> void:
 	instance = self
+
 
 func _physics_process(_delta: float) -> void:
 	if Input.is_action_just_pressed("roll"):
@@ -48,16 +62,58 @@ func _physics_process(_delta: float) -> void:
 			## We normalize the shit out of everything so we can multiply it by a consistent speed.
 			## This way there's no weird acceleration or slowdown.
 			velocity = velocity.move_toward(walking_dir().normalized(), roll_influence).normalized() * roll_speed
-			# TODO: Rolling while not holding any other inputs effectively freezes you.
-			# The previous facing direction should be considered. 
 			
 	move_and_slide()
 
+## We use the proper process function to update stamina, since it appears on the HUD and that could be drawn faster than the physics tickrate.
+func _process(delta: float) -> void:
+	if is_in_combat: update_stamina(delta)
+	# TEST COMBAT ENCOUNTER MODE FOR STAMINA
+	if Input.is_action_just_pressed("ui_focus_next"):
+		match is_in_combat:
+			true:
+				exit_combat()
+			false:
+				enter_combat()
+
 func begin_roll() -> void:
+	# This function only runs when the roll starts. Get out of here if you're already rolling!
+	if current_state == PlayerState.ROLLING: return
+	# We only handle stamina transactions if the player is in combat.
+		# In that case, if the player doesn't have at least one full stamina bar, give up.
+	if is_in_combat:
+		if stamina<1.0: 
+			print("Not enough stamina!")
+			return
+		stamina-=1.0
 	#TODO: Play animation, do iframes.
 	current_state = PlayerState.ROLLING
 	%RollDurationTimer.start()
 	await %RollDurationTimer.timeout
 	current_state = PlayerState.WALKING
-	
-	
+
+## Called every frame if the player is in combat.
+func update_stamina(delta: float) -> void:
+	stamina+=STAMINA_RECHARGE_RATE * delta
+	stamina = clampf(stamina, 0.0, 3.0)
+	$Hud.update_stamina_bar(stamina)
+
+
+# COMBAT ENCOUNTERS
+# According to the GDD, the player will enter Combat Encounters. These involve:
+# - The camera locking
+# - Enemies spawning in a group
+# - Rolling becomes stamina-dependent
+# To handle all of this, some other object should just tell the player about combat encounters with signals.
+# These next two functions are provided to hook your signals into.
+## Call this to tell the player that a combat encounter is beginning.
+func enter_combat() -> void:
+	if is_in_combat: return
+	is_in_combat = true
+	$Hud.fade_stamina_in()
+## Call this to tell the player that a combat encounter is done.
+func exit_combat() -> void:
+	if !is_in_combat: return
+	is_in_combat = false
+	stamina = 3.0
+	$Hud.fade_stamina_out()

--- a/world/player/player.tscn
+++ b/world/player/player.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://nuqmhgq1e2lu"]
+[gd_scene load_steps=8 format=3 uid="uid://nuqmhgq1e2lu"]
 
 [ext_resource type="Script" uid="uid://llqh4g6obmup" path="res://world/player/player.gd" id="1_bvkkv"]
 [ext_resource type="Texture2D" uid="uid://ckv48omi8han7" path="res://temp_art/gartic/harry_potter_with_gun.png" id="1_yynsy"]
+[ext_resource type="PackedScene" uid="uid://bas8xwk5nhlq0" path="res://world/player/HUD/hud.tscn" id="2_duds0"]
 [ext_resource type="PackedScene" uid="uid://cj5uuu7xjsprv" path="res://world/player/weapon/basic_gun/basic_gun.tscn" id="3_et4on"]
 [ext_resource type="Script" uid="uid://c4s1ohnc08ecy" path="res://world/player/reticle/reticle.gd" id="4_40qjc"]
 [ext_resource type="Texture2D" uid="uid://bwm425xkr0vcy" path="res://temp_art/icon.svg" id="4_et4on"]
@@ -12,6 +13,8 @@ radius = 0.669922
 
 [node name="Player" type="CharacterBody3D" groups=["player"]]
 script = ExtResource("1_bvkkv")
+
+[node name="Hud" parent="." instance=ExtResource("2_duds0")]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.94693, 0)

--- a/world/player/weapon/basic_gun/basic_gun.gd
+++ b/world/player/weapon/basic_gun/basic_gun.gd
@@ -3,7 +3,8 @@ extends Node3D
 @onready var player: Player = get_parent()
 
 func _process(_delta: float) -> void:
-	if Input.is_action_just_pressed("fire"):
+	# No shooting if you're rolling!
+	if Input.is_action_just_pressed("fire") && !player.current_state==player.PlayerState.ROLLING:
 		fire()
 
 func fire() -> void:


### PR DESCRIPTION
Roll should now be to spec. Edited the basic_gun to also be unable to shoot during a roll.

**What issue does this close? For multiple, write a line for each.**
Closes #271

**Summarize what's new, especially anything not mentioned in the issue.**

Combat Encounter mode has been started and can be tested by pressing TAB. In the actual game, this mode is only active while in combat. In this mode, rolling costs stamina. The stamina HUD fades in only during this mode, and fades out afterwards. The real Combat Encounters will be toggled by triggering and defeating enemy groups, I've left the functions `enter_combat()` and `exit_combat()` in the Player script for those hypothetical triggers to activate.

Rolling is also meant to disable all input other than moving or pausing. A check inside `basic_gun.gd` was added to make sure the player isn't rolling when they shoot. This will need to be done for all player weapons.

This is also the first introduction of the HUD to the project, so I left some notes explaining how it might be used in its script. Currently it has functions just for updating the stamina bar's value and visibility, which are all used by the player.

**If there's any remaining work needed, describe that here.**
The TAB test code (search for TEST in player.gd) should eventually be axed. Also, please please please tell the design team to be consistent if it's a "roll" or "dash"!!! 

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Open a scene with the player in it such as `demo_a.tscn` and press TAB. Run around, roll and shoot, then press TAB a few more times.