### PR TITLE
Player health 153

### DIFF
--- a/test_scenes/example_scene.tscn
+++ b/test_scenes/example_scene.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=7 format=3 uid="uid://d3o7riajla512"]
 
-[ext_resource type="PackedScene" uid="uid://cr05xakri7lnw" path="res://world/floor/floor_gen.tscn" id="1_plfsl"]
+[ext_resource type="PackedScene" path="res://world/floor/floor_gen.tscn" id="1_plfsl"]
 [ext_resource type="Texture2D" uid="uid://cjbsq7rk6r3h4" path="res://temp_art/gartic/cactus.png" id="2_p5u37"]
 [ext_resource type="Texture2D" uid="uid://sxaysn4gqoxo" path="res://temp_art/gartic/coin.png" id="3_p5u37"]
 [ext_resource type="PackedScene" uid="uid://dxdkwdigtcn43" path="res://world/enemy/test/enemy_test.tscn" id="4_wceyb"]
-[ext_resource type="PackedScene" uid="uid://nuqmhgq1e2lu" path="res://world/player/player.tscn" id="5_plfsl"]
+[ext_resource type="PackedScene" uid="uid://ddvs7q6wq2x24" path="res://world/player/player.tscn" id="5_plfsl"]
 
 [sub_resource type="Curve3D" id="Curve3D_plfsl"]
 closed = true
@@ -37,12 +37,11 @@ texture = ExtResource("2_p5u37")
 transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 11.5831, 1.00557, 0.341141)
 texture = ExtResource("3_p5u37")
 
-[node name="EnemyTest" parent="." instance=ExtResource("4_wceyb")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.249423, 4.7683716e-07, -2.0285115)
-script = null
-
 [node name="Player" parent="." instance=ExtResource("5_plfsl")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.53553, 4.7683716e-07, 0.9444761)
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.92473876, -0.25272667, 0.28458285, 0, 0.74771696, 0.66401756, -0.3806024, -0.61404276, 0.69144285, 0, 0, 0)
+
+[node name="EnemyTest" parent="." instance=ExtResource("4_wceyb")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.967405, 0.21243383, -2.4229155)

--- a/world/enemy/test/enemy_test.gd
+++ b/world/enemy/test/enemy_test.gd
@@ -3,4 +3,9 @@ extends CharacterBody3D
 func _on_damage_area_body_entered(body: Node3D) -> void:
 	if body is Player:
 		body.hurt(1)
-	print("GET REKT")
+
+func _physics_process(_delta: float) -> void:
+	if $DamageArea.has_overlapping_bodies():
+		for y: Node3D in $DamageArea.get_overlapping_bodies():
+			if y is Player:
+				y.hurt(1)

--- a/world/enemy/test/enemy_test.gd
+++ b/world/enemy/test/enemy_test.gd
@@ -1,0 +1,6 @@
+extends CharacterBody3D
+
+func _on_damage_area_body_entered(body: Node3D) -> void:
+	if body is Player:
+		body.hurt(1)
+	print("GET REKT")

--- a/world/enemy/test/enemy_test.gd.uid
+++ b/world/enemy/test/enemy_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b8r0revy8713y

--- a/world/enemy/test/enemy_test.tscn
+++ b/world/enemy/test/enemy_test.tscn
@@ -1,9 +1,22 @@
-[gd_scene load_steps=3 format=3 uid="uid://dxdkwdigtcn43"]
+[gd_scene load_steps=5 format=3 uid="uid://dxdkwdigtcn43"]
 
 [ext_resource type="PackedScene" uid="uid://dx3l0wduat3tp" path="res://world/enemy/base/enemy_base.tscn" id="1_gbmv4"]
+[ext_resource type="Script" uid="uid://b8r0revy8713y" path="res://world/enemy/test/enemy_test.gd" id="2_xuwp2"]
 [ext_resource type="Texture2D" uid="uid://ccalgafhbfwhn" path="res://temp_art/gartic/raccoon_with_gun.png" id="2_yh6x6"]
 
-[node name="EnemyTest" instance=ExtResource("1_gbmv4")]
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_yh6x6"]
+radius = 1.241
 
-[node name="Sprite3D" parent="." index="1"]
+[node name="EnemyTest" instance=ExtResource("1_gbmv4")]
+script = ExtResource("2_xuwp2")
+
+[node name="DamageArea" type="Area3D" parent="." index="0"]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="DamageArea" index="0"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8768897, 0)
+shape = SubResource("CylinderShape3D_yh6x6")
+
+[node name="Sprite3D" parent="." index="2"]
 texture = ExtResource("2_yh6x6")
+
+[connection signal="body_entered" from="DamageArea" to="." method="_on_damage_area_body_entered"]

--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -7,7 +7,7 @@ class_name Player extends CharacterBody3D
 @export var roll_duration: float = 0.4
 @export var roll_influence: float = 8 ## Controls how much player input affects steering when mid-roll. 
 
-@export var player_health: int = 10
+@export var player_health: int = 3
 
 ## These are the states that the player can be in. States control what the player can do.
 enum PlayerState {
@@ -16,7 +16,7 @@ enum PlayerState {
 }
 
 var invulnerable: bool = false
-var hurt_invuln_time: float = 1
+var hurt_invuln_time: float = 0.5
 
 var current_state: PlayerState = PlayerState.WALKING
 
@@ -59,6 +59,11 @@ func hurt(damage: int) -> void:
 		
 	print("HIT! " + str(player_health) + " HP left")
 	player_health -= damage
+	
+	if player_health <= 0:
+		print("HEALTH IS 0! DYING...")
+		get_tree().reload_current_scene()
+		return
 	
 	invulnerable = true
 	$Sprite3D.modulate = Color(1,0,0,1)

--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -54,7 +54,6 @@ func begin_roll() -> void:
 	
 func hurt(damage: int) -> void:
 	if invulnerable:  
-		print("Damage Nullified")
 		return
 		
 	print("HIT! " + str(player_health) + " HP left")

--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -1,4 +1,4 @@
-extends CharacterBody3D
+class_name Player extends CharacterBody3D
 
 ## EXPORT VARIABLES
 @export var walk_speed: float = 8.0
@@ -7,11 +7,16 @@ extends CharacterBody3D
 @export var roll_duration: float = 0.4
 @export var roll_influence: float = 8 ## Controls how much player input affects steering when mid-roll. 
 
+@export var player_health: int = 10
+
 ## These are the states that the player can be in. States control what the player can do.
 enum PlayerState {
 	WALKING,
 	ROLLING
 }
+
+var invulnerable: bool = false
+var hurt_invuln_time: float = 1
 
 var current_state: PlayerState = PlayerState.WALKING
 
@@ -19,6 +24,8 @@ var current_state: PlayerState = PlayerState.WALKING
 func walking_dir() -> Vector3:
 	var input := Input.get_vector("move_left", "move_right", "move_up", "move_down")
 	return Vector3(input.x, 0, input.y)
+	
+
 
 func _physics_process(_delta: float) -> void:
 	if Input.is_action_just_pressed("roll"):
@@ -44,5 +51,20 @@ func begin_roll() -> void:
 	%RollDurationTimer.start()
 	await %RollDurationTimer.timeout
 	current_state = PlayerState.WALKING
+	
+func hurt(damage: int) -> void:
+	if invulnerable:  
+		print("Damage Nullified")
+		return
+		
+	print("HIT! " + str(player_health) + " HP left")
+	player_health -= damage
+	
+	invulnerable = true
+	$Sprite3D.modulate = Color(1,0,0,1)
+	await get_tree().create_timer(hurt_invuln_time).timeout
+	$Sprite3D.modulate = Color(1,1,1,1)
+	invulnerable = false
+	
 	
 	

--- a/world/player/player.tscn
+++ b/world/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://nuqmhgq1e2lu"]
+[gd_scene load_steps=4 format=3 uid="uid://ddvs7q6wq2x24"]
 
 [ext_resource type="Script" uid="uid://llqh4g6obmup" path="res://world/player/player.gd" id="1_bvkkv"]
 [ext_resource type="Texture2D" uid="uid://ckv48omi8han7" path="res://temp_art/gartic/harry_potter_with_gun.png" id="1_yynsy"]


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
#153 

**Summarize what's new, especially anything not mentioned in the issue.**
Added Player health, invulnerability after damage, and added a hurtbox to enemy_test.

**If there's any remaining work needed, describe that here.**
Currently, in enemy_test.gd an if statement runs every physics tick that checks whether the player is inside its hurtbox. I didn't know a better way to fix the issue of the player not taking damage more than once after entering the hurtbox, but this feels like the wrong way to do so. 

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Enter example_scene, then run into the enemy_test node. The player should turn red for 0.5 seconds, then return to normal, assuming the player exits the hurtbox. When the player takes damage 3 times, the scene should reset.  