### PR TITLE
Modular Components for reusable health & damage

### DIFF
--- a/components/damage/damage_component.gd
+++ b/components/damage/damage_component.gd
@@ -1,0 +1,12 @@
+class_name DamageComponent extends Node
+
+enum Source{
+	PLAYER,
+	ENEMY,
+	NEUTRAL
+}
+
+@export var damage : int
+@export var source : Source
+@export var knockback : float
+@export var stun_time : float

--- a/components/damage/damage_component.gd.uid
+++ b/components/damage/damage_component.gd.uid
@@ -1,0 +1,1 @@
+uid://bhpagy0iq3tpw

--- a/components/damage/damage_component.tscn
+++ b/components/damage/damage_component.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://007x0lj0h4n0"]
+
+[ext_resource type="Script" uid="uid://bhpagy0iq3tpw" path="res://components/damage/damage_component.gd" id="1_t37o0"]
+
+[node name="DamageComponent" type="Node"]
+script = ExtResource("1_t37o0")

--- a/components/health/health_component.gd
+++ b/components/health/health_component.gd
@@ -1,0 +1,19 @@
+class_name HealthComponent extends Node
+
+signal killed
+
+@export var max_health : int
+
+var health : int
+
+func _ready() -> void:
+	health = max_health
+
+func hurt(amount : int) -> void:
+	health-=amount
+	print(get_parent().name,": ",health," hp")
+	if health <= 0:
+		killed.emit()
+
+func heal(amount : int) -> void:
+	health = clampi(health+amount,0,max_health)

--- a/components/health/health_component.gd.uid
+++ b/components/health/health_component.gd.uid
@@ -1,0 +1,1 @@
+uid://do5vs8m1law7o

--- a/components/health/health_component.tscn
+++ b/components/health/health_component.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://hiyp7n7uvc4m"]
+
+[ext_resource type="Script" uid="uid://do5vs8m1law7o" path="res://components/health/health_component.gd" id="1_npdka"]
+
+[node name="HealthComponent" type="Node"]
+script = ExtResource("1_npdka")

--- a/components/hurtbox/hurtbox_component.gd
+++ b/components/hurtbox/hurtbox_component.gd
@@ -1,0 +1,15 @@
+class_name HurtboxComponent extends Area3D
+
+
+
+@export var health_component : HealthComponent
+@export var allowed_damage_sources : Array[DamageComponent.Source]
+
+func _ready() -> void:
+	assert(health_component != null, "No health component added")
+
+
+
+func hit(damage_component: DamageComponent) -> void:
+	if allowed_damage_sources.has(damage_component.source):
+		health_component.hurt(damage_component.damage)

--- a/components/hurtbox/hurtbox_component.gd.uid
+++ b/components/hurtbox/hurtbox_component.gd.uid
@@ -1,0 +1,1 @@
+uid://lxg83i28nlul

--- a/components/hurtbox/hurtbox_component.tscn
+++ b/components/hurtbox/hurtbox_component.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b7d3oiw27awag"]
+
+[ext_resource type="Script" uid="uid://lxg83i28nlul" path="res://components/hurtbox/hurtbox_component.gd" id="1_moset"]
+
+[node name="HurtboxComponent" type="Area3D"]
+script = ExtResource("1_moset")

--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,7 @@ window/stretch/mode="canvas_items"
 
 folder_colors={
 "res://audio/": "red",
+"res://components/": "blue",
 "res://menu/": "orange",
 "res://systems/": "teal",
 "res://systems/save/": "teal",

--- a/test_scenes/demo1/demo_a.tscn
+++ b/test_scenes/demo1/demo_a.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://btuw2i28k0axl"]
+[gd_scene load_steps=6 format=3 uid="uid://btuw2i28k0axl"]
 
 [ext_resource type="PackedScene" uid="uid://bk60c4813t663" path="res://world/levels/level_base.tscn" id="1_p0tjl"]
 [ext_resource type="Texture2D" uid="uid://cjbsq7rk6r3h4" path="res://temp_art/gartic/cactus.png" id="2_yl5fl"]
+[ext_resource type="PackedScene" uid="uid://dxdkwdigtcn43" path="res://world/enemy/test/enemy_test.tscn" id="4_hxoc3"]
 [ext_resource type="PackedScene" uid="uid://rberd5xw8srm" path="res://world/transitions/transition.tscn" id="4_yl5fl"]
 
 [sub_resource type="Curve3D" id="Curve3D_lkd7d"]
@@ -39,3 +40,6 @@ target_entry_point = "Left"
 
 [node name="Right" type="Marker3D" parent="EntryPoints" index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16.214909, 0, 0.96318436)
+
+[node name="EnemyTest" parent="." index="5" instance=ExtResource("4_hxoc3")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.065703, 0.21243535, -0.2136469)

--- a/world/enemy/base/enemy_base.tscn
+++ b/world/enemy/base/enemy_base.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dx3l0wduat3tp"]
+[gd_scene load_steps=5 format=3 uid="uid://dx3l0wduat3tp"]
 
 [ext_resource type="Script" uid="uid://duwt050r1xw07" path="res://world/enemy/base/enemy_base.gd" id="1_1uty2"]
+[ext_resource type="PackedScene" uid="uid://hiyp7n7uvc4m" path="res://components/health/health_component.tscn" id="2_17eo5"]
+[ext_resource type="PackedScene" uid="uid://b7d3oiw27awag" path="res://components/hurtbox/hurtbox_component.tscn" id="3_1tv51"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_plfsl"]
 height = 1.85699
@@ -15,3 +17,14 @@ shape = SubResource("CylinderShape3D_plfsl")
 
 [node name="Sprite3D" type="Sprite3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 1, 0)
+
+[node name="HealthComponent" parent="." instance=ExtResource("2_17eo5")]
+max_health = 10
+
+[node name="HurtboxComponent" parent="." node_paths=PackedStringArray("health_component") instance=ExtResource("3_1tv51")]
+health_component = NodePath("../HealthComponent")
+allowed_damage_sources = Array[int]([0])
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="HurtboxComponent"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.94693, 0)
+shape = SubResource("CylinderShape3D_plfsl")

--- a/world/player/weapon/bullet/player_bullet.gd
+++ b/world/player/weapon/bullet/player_bullet.gd
@@ -1,6 +1,8 @@
 class_name Bullet
 extends Area3D
 
+@export var damage_component : DamageComponent
+
 const SPEED := 40.0
 
 var velocity: Vector3
@@ -14,5 +16,9 @@ func _process(delta: float) -> void:
 
 func _on_body_entered(body: Node3D) -> void:
 	print("Bullet hit `%s`" % body.name)
-	if body.has_method("hit"):
-		body.hit(self)
+
+
+func _on_area_entered(area: Area3D) -> void:
+	if area is HurtboxComponent:
+		var hurtbox : HurtboxComponent = area
+		hurtbox.hit(damage_component)

--- a/world/player/weapon/bullet/player_bullet.tscn
+++ b/world/player/weapon/bullet/player_bullet.tscn
@@ -1,13 +1,15 @@
-[gd_scene load_steps=4 format=3 uid="uid://bq22o80xk3p40"]
+[gd_scene load_steps=5 format=3 uid="uid://bq22o80xk3p40"]
 
 [ext_resource type="Script" uid="uid://bykjiyhskge1i" path="res://world/player/weapon/bullet/player_bullet.gd" id="1_0g3v8"]
 [ext_resource type="Texture2D" uid="uid://sxaysn4gqoxo" path="res://temp_art/gartic/coin.png" id="1_bnpoh"]
+[ext_resource type="PackedScene" uid="uid://007x0lj0h4n0" path="res://components/damage/damage_component.tscn" id="3_njpx5"]
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_0g3v8"]
 radius = 0.2795053
 
-[node name="PlayerBullet" type="Area3D"]
+[node name="PlayerBullet" type="Area3D" node_paths=PackedStringArray("damage_component")]
 script = ExtResource("1_0g3v8")
+damage_component = NodePath("DamageComponent")
 
 [node name="Sprite3D" type="Sprite3D" parent="."]
 transform = Transform3D(0.41249996, 0, 0, 0, 0.2916815, 0.2916815, 0, -0.2916815, 0.2916815, 0, 0, 0)
@@ -16,4 +18,8 @@ texture = ExtResource("1_bnpoh")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 shape = SubResource("SphereShape3D_0g3v8")
 
+[node name="DamageComponent" parent="." instance=ExtResource("3_njpx5")]
+damage = 2
+
+[connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Doesn't close any specific issue, but Michael asked me to do enemy health, and suggested I make it modular.
This feature is currently planned to be used by
- #294 (I asked Ethan beforehand)
- #254 (The one I'm working on)
and could probably be used in #267 (I saw two different branches for cover, so I think a miscommunication of some sort has happend there) 

**Summarize what's new, especially anything not mentioned in the issue.**
Creates 3 reusable components: HealthComponent, DamageComponent, and HurtboxComponent. It is designed to be modular and work with anything that can take damage.

**If there's any remaining work needed, describe that here.**
- Attaching these components to the systems described above (#294 #254 and #267)
- Implementing functionality (possibly also components) for stun & invulnerability once enemy movement is finished 

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Test that the hurtbox component's allowed damage source actually limits what can hurt the entity it's attached to (a simple example with player's bullets damage a test enemy is set up in demo_a)