### PR TITLE
Fixed player stamina code

### DIFF
--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -110,9 +110,10 @@ func begin_roll() -> void:
 	# This function only runs when the roll starts. Get out of here if you're already rolling!
 	if current_state == PlayerState.ROLLING: return
 	
-	# Factor in stamina
-	if stamina < 1.0: return
-	stamina -= 1.0
+	# Factor in stamina only if player is in combat:
+	if is_in_combat:
+		if stamina < 1.0: return
+		stamina -= 1.0
 	
 	#TODO: Play animation, do iframes.
 	current_state = PlayerState.ROLLING
@@ -122,13 +123,9 @@ func begin_roll() -> void:
 
 ## Called every frame if the player is in combat.
 func update_stamina(delta: float) -> void:
-	if is_in_combat:
-		stamina += STAMINA_RECHARGE_RATE * delta
-		stamina = clampf(stamina, 0.0, 3.0)
-		$Hud.update_stamina_bar(stamina)
-	else:
-		stamina = 3.0
-
+	stamina += STAMINA_RECHARGE_RATE * delta
+	stamina = clampf(stamina, 0.0, 3.0)
+	$Hud.update_stamina_bar(stamina)
 
 # COMBAT ENCOUNTERS
 # According to the GDD, the player will enter Combat Encounters. These involve:

--- a/world/player/player.tscn
+++ b/world/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://nuqmhgq1e2lu"]
+[gd_scene load_steps=13 format=3 uid="uid://nuqmhgq1e2lu"]
 
 [ext_resource type="Script" uid="uid://llqh4g6obmup" path="res://world/player/player.gd" id="1_bvkkv"]
 [ext_resource type="Texture2D" uid="uid://ckv48omi8han7" path="res://temp_art/gartic/harry_potter_with_gun.png" id="1_yynsy"]
@@ -19,10 +19,10 @@ radius = 0.669922
 height = 0.27978516
 radius = 0.8881836
 
-[node name="Player" type="CharacterBody3D" node_paths=PackedStringArray("whip", "health_component") groups=["player"]]
+[node name="Player" type="CharacterBody3D" node_paths=PackedStringArray("health_component", "whip") groups=["player"]]
 script = ExtResource("1_bvkkv")
-whip = NodePath("Whip")
 health_component = NodePath("HurtboxComponent/HealthComponent")
+whip = NodePath("Whip")
 
 [node name="Hud" parent="." instance=ExtResource("2_duds0")]
 


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #381


**Summarize what's new, especially anything not mentioned in the issue.**
The player code had some redundant if checks in there, and was pretty blatantly missing one to let the player dash without stamina if they weren't in combat... Which I'm pretty sure was something I did earlier! Stamina is already not deducted outside of combat mode and is automatically refilled when combat ends. All that was missing was wrapping stamina checking/deduction in `if is_in_combat`.

**If there's any remaining work needed, describe that here.**
No, I'm pretty sure this fixes the bug.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Hop into `res://test_scenes/demo1/demo_a.tscn` and roll around. Press TAB, roll some more, press TAB again, keep rolling...