### PR TITLE
Transition Lock in Combat

### DIFF
--- a/world/player/HUD/hud.gd
+++ b/world/player/HUD/hud.gd
@@ -10,16 +10,19 @@ extends Control
 
 @export var stamina_bar: ProgressBar ## The stamina bar itself, which Player tells the stamina value.
 @export var stamina_container: PanelContainer ## The stamina bar's parent that fades in and out.
+var player: Player
 
 var _in_combat := false:
 	set(value):
 		if value == _in_combat: return # no change
 		_in_combat = value
 		
-		if _in_combat: fade_stamina_in()
-		else: fade_stamina_out()
+		if _in_combat: player.enter_combat()
+		else: player.exit_combat()
 
 func _ready() -> void:
+	player =  get_tree().get_first_node_in_group("player")
+	print("LOOK HERE: " + player.to_string())
 	# Stamina bar is hidden by default until player enters a Combat Encounter.
 	$StaminaContainer.modulate.a = 0.0
 

--- a/world/transitions/transition.gd
+++ b/world/transitions/transition.gd
@@ -5,6 +5,11 @@ extends Area3D
 func _on_body_entered(body: Node3D) -> void:
 	if body is not Player: return
 	
+	var player: Player = body
+	if player.is_in_combat:
+		print("is in combat")
+		return
+	
 	Player.update_persisting_data()
 	
 	EntryPoints.set_entry_point(target_entry_point)


### PR DESCRIPTION
The player is now unable to transition to another scene when in combat

**What issue does this close? For multiple, write a line for each.**
Closes #410 

**Summarize what's new, especially anything not mentioned in the issue.**
Transition checks if player.is_in_combat is false before changing scenes

**If there's any remaining work needed, describe that here.**


**How should this be tested? Include what scene it's in, and any steps to test every feature.**
In level_desert_large, enter the first encounter then try to leave the scene (go down). When in encounter, player should be unable to change scenes. Defeat enemies and try transition again.