### PR TITLE
Clamped reticle's position to Viewport bounds

### DIFF
--- a/test_scenes/example_scene.tscn
+++ b/test_scenes/example_scene.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://cr05xakri7lnw" path="res://world/floor/floor_gen.tscn" id="1_plfsl"]
 [ext_resource type="Texture2D" uid="uid://cjbsq7rk6r3h4" path="res://temp_art/gartic/cactus.png" id="2_p5u37"]
-[ext_resource type="Script" uid="uid://duvasrdv76uic" path="res://test_scenes/test_coin.gd" id="3_0u0ns"]
+[ext_resource type="Script" path="res://test_scenes/test_coin.gd" id="3_0u0ns"]
 [ext_resource type="Texture2D" uid="uid://sxaysn4gqoxo" path="res://temp_art/gartic/coin.png" id="3_p5u37"]
 [ext_resource type="PackedScene" uid="uid://nuqmhgq1e2lu" path="res://world/player/player.tscn" id="5_plfsl"]
 [ext_resource type="PackedScene" uid="uid://b4n4rflu3my0v" path="res://world/enemy/longhorn/longhorn.tscn" id="7_byltu"]

--- a/world/player/reticle/reticle.gd
+++ b/world/player/reticle/reticle.gd
@@ -3,16 +3,16 @@ extends Node3D
 @export var solve_height : float = 1
 
 func _process(delta: float) -> void:
+	var min_bounds:Vector2 = Vector2(0,0)
+	var max_bounds:Vector2 = get_viewport().get_visible_rect().size
 	var cam := get_viewport().get_camera_3d()
-	var mouse := get_viewport().get_mouse_position()
+	var mouse := get_viewport().get_mouse_position().clamp(min_bounds, max_bounds)
 	var ray_origin := cam.project_ray_origin(mouse)
 	var ray_dir := cam.project_ray_normal(mouse)
-	
 	# ray_origin + ray_dir * t = (x, y, z)
 	# y = 1
 	# ray_origin.y + ray_dir.y * t = solve_height
 	# rey_dir.y * t = solve_height-ray_origin.y
 	# t = -ray_origin.y / ray_dir.y
 	var t := (solve_height-ray_origin.y) / ray_dir.y
-
-	global_position = ray_origin + ray_dir * t
+	global_position = (ray_origin + ray_dir * t)

--- a/world/player/weapon/whip/whip.tscn
+++ b/world/player/weapon/whip/whip.tscn
@@ -46,6 +46,7 @@ charge_levels = Array[ExtResource("2_kmd03")]([SubResource("Resource_kmd03"), Su
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0, 0)
 
 [node name="Area3D" type="Area3D" parent="Attack"]
+collision_mask = 9
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Attack/Area3D"]
 transform = Transform3D(6, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0, 0)


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #399 

**Summarize what's new, especially anything not mentioned in the issue.**
The reticle (which follows the cursor) is not unable to move past the bounds of the viewport (window).

**If there's any remaining work needed, describe that here.**
...

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Should work in any scene where the player is present. If you make the window small and circle your mouse around the window, everything should be working properly.