### PR TITLE
Forces player to stay at same y-position from the start

### DIFF
--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -47,6 +47,8 @@ var stamina: float = 3.0
 const STAMINA_RECHARGE_RATE: float = 0.666667
 
 var current_state: PlayerState = PlayerState.WALKING
+
+@onready var starting_y_pos : float = position.y
 #endregion
 
 static func update_persisting_data() -> void:
@@ -95,7 +97,9 @@ func _physics_process(delta: float) -> void:
 		## We normalize the shit out of everything so we can multiply it by a consistent speed.
 		## This way there's no weird acceleration or slowdown.
 		roll(delta)
+	
 	move_and_slide()
+	position.y = starting_y_pos # ensures that player does not move above starting plane
 
 ## Returns the inputted walking direction on the XZ plane (Y = 0)
 func input_direction() -> Vector3:


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #422 

**Summarize what's new, especially anything not mentioned in the issue.**
Sets the player's y-position every frame to the y-position the player had at the start of the scene. This was done instead of simply setting the player's y-position to zero, to future-proof against variations in environment plane y-positions.

**If there's any remaining work needed, describe that here.**
No further work is needed in this regard.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
The player will no longer be forced upwards when being forced between tight crevices, such as the rock mentioned in the issue.