### PR TITLE
Walking Sounds

### DIFF
--- a/test_scenes/example_scene.tscn
+++ b/test_scenes/example_scene.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://cr05xakri7lnw" path="res://world/floor/floor_gen.tscn" id="1_plfsl"]
 [ext_resource type="Texture2D" uid="uid://cjbsq7rk6r3h4" path="res://temp_art/gartic/cactus.png" id="2_p5u37"]
-[ext_resource type="Script" path="res://test_scenes/test_coin.gd" id="3_0u0ns"]
+[ext_resource type="Script" uid="uid://duvasrdv76uic" path="res://test_scenes/test_coin.gd" id="3_0u0ns"]
 [ext_resource type="Texture2D" uid="uid://sxaysn4gqoxo" path="res://temp_art/gartic/coin.png" id="3_p5u37"]
 [ext_resource type="PackedScene" uid="uid://nuqmhgq1e2lu" path="res://world/player/player.tscn" id="5_plfsl"]
 [ext_resource type="PackedScene" uid="uid://b4n4rflu3my0v" path="res://world/enemy/longhorn/longhorn.tscn" id="7_byltu"]
@@ -27,6 +27,7 @@ point_count = 4
 [node name="Player" parent="." instance=ExtResource("5_plfsl")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.53553, 4.7683716e-07, 0.9444761)
 walk_speed = 20.0
+floor_type = 1
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.92473876, -0.25272667, 0.28458285, 0, 0.74771696, 0.66401756, -0.3806024, -0.61404276, 0.69144285, 0, 0, 0)

--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -49,6 +49,14 @@ const STAMINA_RECHARGE_RATE: float = 0.666667
 var current_state: PlayerState = PlayerState.WALKING
 #endregion
 
+enum FloorType{ ## Where the player is walking
+	WOOD,
+	SAND,
+	STONE,
+	STONE_SOFT,
+}
+@export var floor_type: FloorType
+
 static func update_persisting_data() -> void:
 	## Make it so this can change to whatever the current gun is?
 	var gun := instance.get_node(gun_name)
@@ -68,6 +76,7 @@ static func update_persisting_data() -> void:
 #region Builtin Functions
 func _ready() -> void:
 	var gun := instance.get_node(gun_name)
+	walking_sounds() #Sets the player's walking sound. 
 	
 	instance = self
 	if persisting_data != null:
@@ -87,8 +96,11 @@ func _physics_process(delta: float) -> void:
 	if current_state == PlayerState.WALKING:
 		var input_dir : Vector3 = input_direction()
 		velocity = input_dir * walk_speed * speed_multiplier
+		#$WalkSFX.play() 
+		#print($WalkSFX.stream)
 		if input_dir != Vector3.ZERO:
 			previous_input_direction = input_dir
+		
 	elif current_state == PlayerState.ROLLING:
 		## We move the velocity vector towards the direction of the movement. 
 		## This means that velocity doesn't immediately become where we're pointing, but changes over time.
@@ -169,7 +181,16 @@ func update_stamina(delta: float) -> void:
 		$Hud.update_stamina_bar(stamina)
 	else:
 		stamina = 3.0
-
+func walking_sounds()->void: #Determines what sound the player should make when walking
+	match floor_type:
+		FloorType.WOOD:
+			$WalkSFX.stream = load("res://audio/placeholders/funny_bone_man.wav")
+		FloorType.SAND:
+			$WalkSFX.stream = load("res://audio/dialog_sounds/se_npc_textbox_talk/se_npc_textbox_talkB.wav")
+	
+		
+		
+	
 
 # COMBAT ENCOUNTERS
 # According to the GDD, the player will enter Combat Encounters. These involve:

--- a/world/player/player.tscn
+++ b/world/player/player.tscn
@@ -56,7 +56,6 @@ shape = SubResource("CylinderShape3D_bvkkv")
 
 [node name="BasicGun" parent="." instance=ExtResource("3_et4on")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2370036, 0)
-bullets_of_fire_unlocked = null
 
 [node name="Aiming" type="Node" parent="."]
 
@@ -116,3 +115,5 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9011965, 0)
 light_energy = 0.2
 omni_range = 25.0
 omni_attenuation = 1.5
+
+[node name="WalkSFX" type="AudioStreamPlayer3D" parent="."]


### PR DESCRIPTION
Added a function to switch the sound the player is walking with

**What issue does this close? For multiple, write a line for each.**
Closes #436 

**Summarize what's new, especially anything not mentioned in the issue.**
...
Added new enum floor types in player.gd
Added new function walking_sounds() that will determine the sound in player.gd
Added walking sound node to player.

**If there's any remaining work needed, describe that here.**
...
Need to check if player is walking in a puddle

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
...
$WalkingSFX.play() in whatever makes the player walk.