### PR TITLE
Made encounter blockers appear instantly

### DIFF
--- a/world/blocker/blocker.tscn
+++ b/world/blocker/blocker.tscn
@@ -25,5 +25,6 @@ shape = SubResource("ConvexPolygonShape3D_101jw")
 
 [node name="EncounterObject" type="Node" parent="."]
 script = ExtResource("2_egdxf")
+start_instant = true
 hide_on_finish = true
 metadata/_custom_type_script = "uid://5yprj03obbfy"

--- a/world/enemy/encounter/encounter.gd
+++ b/world/enemy/encounter/encounter.gd
@@ -66,7 +66,12 @@ func start_encounter() -> void:
 	progress = EncounterProgress.IN_PROGRESS
 	active_encounter = self
 	%CameraTracked.enabled = true
-	for obj in get_encounter_objects():
+	
+	var objects := get_encounter_objects()
+	for obj in objects:
+		obj.prepare()
+	
+	for obj in objects:
 		obj.start()
 		await get_tree().create_timer(appear_delay, false).timeout
 

--- a/world/enemy/encounter/encounter_obj.gd
+++ b/world/enemy/encounter/encounter_obj.gd
@@ -6,6 +6,10 @@ extends Node
 ## Useful if an enemy is spawned in the middle of an encounter.
 @export var start_active := false
 
+## If true, this object will immediately activate when an encounter starts.
+## Otherwise, there will be an animated delay.
+@export var start_instant := false
+
 ## True if the object should hide itself after the encounter finishes.
 @export var hide_on_finish := false
 
@@ -34,9 +38,16 @@ func hide() -> void:
 	p.visible = false
 	p.process_mode = PROCESS_MODE_DISABLED
 
+## Called on all objects immediately when the encounter starts.
+## Different from `start`, which is called after some animated delay.
+func prepare() -> void:
+	if start_instant: start()
+
 ## Called when the encounter starts. Makes the object appear, with a little animation.
 ## Note that each object's start method is called one after another, with a delay between each one.
 func start() -> void:
+	if _started: return
+	
 	_started = true
 	
 	var p: Node3D = get_parent()
@@ -47,7 +58,7 @@ func start() -> void:
 	var y := p.position.y
 	p.position.y = -5.0
 	var tween := create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
-	tween.tween_property(p, "position:y", y, 0.3)
+	tween.tween_property(p, "position:y", y, 0.01 if start_instant else 0.3)
 	await tween.finished
 	
 


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #499 

**Summarize what's new, especially anything not mentioned in the issue.**
Blockers now appear instantly in an encounter. Other enemies still pop in one at a time to look nice.

**If there's any remaining work needed, describe that here.**
...

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Go to any encounter and observe the blockers.