### PR TITLE
Moved encounter2 encounter collision shape

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="DEADSHOT"
-run/main_scene="uid://crgv6bkolrlyy"
+run/main_scene="uid://by8y1gjlttw6g"
 config/features=PackedStringArray("4.5")
 config/icon="res://temp_art/icon.svg"
 


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #536

**Summarize what's new, especially anything not mentioned in the issue.**
Moved and changed the shape of the encounter's collision box. Now the player cannot get stuck when walking backwards into that encounter.

**If there's any remaining work needed, describe that here.**
Review shape of encounter collider?

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Go into desert_level_large, place the player right before the boss, and walk into the encounter backwards. It should no longer block the player from entering and instead trigger when the player is in that encounter. Check Encounter2's Encounter collision shape.