### PR TITLE
Update encounter completion logic for CorruptHeart

### DIFF
--- a/world/enemy/bosses/horse/horse_boss.gd
+++ b/world/enemy/bosses/horse/horse_boss.gd
@@ -156,7 +156,7 @@ func mass_chunks_charge() -> void:
 	for i in range(mass_chunk_amount):
 		var chunk_position : Vector3 = player_position + neutral_spread(0,player_still_spread_distance)
 
-		if not arena_area.is_point_in_arena(chunk_position): #is_point_in_arena caused crash
+		if not (arena_area and arena_area.is_point_in_arena(chunk_position)): #is_point_in_arena caused crash
 			return
 		
 		var bullet_reference: Node3D = splash_obj.instantiate()

--- a/world/enemy/encounter/encounter.gd
+++ b/world/enemy/encounter/encounter.gd
@@ -89,7 +89,7 @@ func end_encounter() -> void:
 
 func _is_encounter_done() -> bool:
 	for o: EncounterObject in get_encounter_objects():
-		if o.is_enemy(): return false
+		if o.blocks_completion(): return false
 	
 	return true
 

--- a/world/enemy/encounter/encounter_obj.gd
+++ b/world/enemy/encounter/encounter_obj.gd
@@ -78,5 +78,5 @@ func finish() -> void:
 func is_active() -> bool:
 	return _started
 
-func is_enemy() -> bool:
-	return get_parent() is EnemyBase
+func blocks_completion() -> bool:
+	return get_parent() is EnemyBase or get_parent() is CorruptHeart

--- a/world/pickups/corrupt_heart/corrupt_heart.gd
+++ b/world/pickups/corrupt_heart/corrupt_heart.gd
@@ -1,3 +1,4 @@
+class_name CorruptHeart
 extends Node3D
 
 @export var health : Health
@@ -23,6 +24,9 @@ func _process(delta: float) -> void:
 func on_death() -> void:
 	dying = true
 	$AnimationPlayer.play("death")
+	
+	# Remove encounter metadata so the encounter can end while animating
+	remove_meta("encounter_object")
 	
 	##Steady stream of blood
 	var blood_burst : GPUParticles3D = blood_burst_packed.instantiate()

--- a/world/pickups/corrupt_heart/corrupt_heart.tscn
+++ b/world/pickups/corrupt_heart/corrupt_heart.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://b0ttk38sufgur"]
+[gd_scene load_steps=17 format=3 uid="uid://b0ttk38sufgur"]
 
 [ext_resource type="Texture2D" uid="uid://di2fa8ln64nqe" path="res://world/pickups/corrupt_heart/corrupt_heart.png" id="1_sj4sw"]
 [ext_resource type="Script" uid="uid://1vuuexllss1q" path="res://world/pickups/corrupt_heart/corrupt_heart.gd" id="1_vve5n"]
@@ -10,6 +10,7 @@
 [ext_resource type="Script" uid="uid://do5vs8m1law7o" path="res://systems/attacking/health/health.gd" id="6_5roo4"]
 [ext_resource type="AudioStream" uid="uid://de23avhh4wkr3" path="res://audio/placeholders/heart_beat1.wav" id="6_kyt37"]
 [ext_resource type="AudioStream" uid="uid://ftg5bow5xo32" path="res://audio/placeholders/heart_beat2.wav" id="7_1n52r"]
+[ext_resource type="Script" uid="uid://5yprj03obbfy" path="res://world/enemy/encounter/encounter_obj.gd" id="11_enc"]
 
 [sub_resource type="Animation" id="Animation_vve5n"]
 length = 0.001
@@ -175,3 +176,9 @@ metadata/_custom_type_script = "uid://do5vs8m1law7o"
 
 [node name="BloodEmitCenter" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9867293, 0)
+
+[node name="EncounterObject" type="Node" parent="."]
+script = ExtResource("11_enc")
+start_active = true
+start_instant = true
+metadata/_custom_type_script = "uid://5yprj03obbfy"


### PR DESCRIPTION
Refactored encounter object completion checks to include CorruptHeart, ensuring encounters only end when both boss and CorruptHeart are removed. Added EncounterObject node to corrupt_heart.tscn and class_name to CorruptHeart script. Fixed potential crash in horse_boss.gd by checking arena_area before calling is_point_in_arena.