### PR TITLE
Remove debug print statements and update music call

### DIFF
--- a/menu/cutscenes/cutscene.gd
+++ b/menu/cutscenes/cutscene.gd
@@ -7,19 +7,15 @@ extends Control
 @export var next_scene: PackedScene
 
 func play_timeline(timeline_idx: int) -> void:
-	print("[Cutscene] play_timeline called, pausing at %.2f" % animator.current_animation_position)
 	animator.pause()
 	Dialog.play(timelines[timeline_idx])
 	await text_finished()
-	print("[Cutscene] Dialog done, resuming animation")
 	animator.play()
 
 func goto_music_section(section_name: String, transition_time: float = 0.5) -> void:
-	print("[Cutscene] goto_music_section('%s', %.2f)" % [section_name, transition_time])
 	MainMusicPlayer.goto_section(section_name, transition_time)
 
 func set_music_volume(level: float, duration: float = 0.0) -> void:
-	print("[Cutscene] set_music_volume(%.2f, %.2f)" % [level, duration])
 	MainMusicPlayer.set_volume(level, duration)
 
 func _ready()->void:
@@ -32,7 +28,7 @@ func _ready()->void:
 	
 	#animator.play("before_dialogue")
 	#await animator.animation_finished
-#
+	#
 	#Dialog.play(timeline)
 	#await text_finished()
 	#

--- a/world/enemy/encounter/encounter.gd
+++ b/world/enemy/encounter/encounter.gd
@@ -70,7 +70,7 @@ func start_encounter() -> void:
 	active_encounter = self
 	%CameraTracked.enabled = true
 	
-	MainMusicPlayer.push_song(encounter_song)
+	MainMusicPlayer.push_song(encounter_song, 0.0, 0.0)
 	
 	var objects := get_encounter_objects()
 	for obj in objects:


### PR DESCRIPTION
Removed debug print statements from cutscene.gd. Updated MainMusicPlayer.push_song call in encounter.gd to push the song right away with no transition