### PR TITLE
Loading save with the correct number of hearts

### DIFF
--- a/world/player/HUD/heart_display.gd
+++ b/world/player/HUD/heart_display.gd
@@ -5,6 +5,7 @@ extends Control
 @export var empty_tex: Texture2D
 
 func _ready() -> void:
+	await Player.instance.player_ready
 	set_hp(Player.instance.health_component.health)
 	set_max_hp(Player.instance.health_component.max_health)
 	

--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -18,6 +18,7 @@ enum PlayerState {
 #region Variables
 static var persisting_data : PlayerPersistingData
 static var instance : Player
+signal player_ready
 
 var speed_multiplier: float = 1.0
 
@@ -121,6 +122,8 @@ func _ready() -> void:
 		if skill in hp_skills:
 			health_component.modify_max_health(-2)
 	)
+	
+	player_ready.emit()
 
 func _init() -> void:
 	instance = self


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #586 - New hearts disappear after reloading a save

**Summarize what's new, especially anything not mentioned in the issue.**
After defeating a boss and gaining a heart, closing the game and loading the save now displays the acquired heart.

**If there's any remaining work needed, describe that here.**
N/A

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Play the game, defeat the first boss, and then save at the campfire. Close the game. Load the save, and there are now 4 hearts instead of 3.