### PR TITLE
Pause menu can load a saved state

### DIFF
--- a/menu/pause_menu/pause_menu.gd
+++ b/menu/pause_menu/pause_menu.gd
@@ -16,7 +16,6 @@ func _ready() -> void:
 	menu_button.pressed.connect(_on_menu_pressed)
 
 	hide()
-	
 
 func _process(_delta: float) -> void:
 	#Makes ESC key toggle pause menu visibility
@@ -32,24 +31,24 @@ func _process(_delta: float) -> void:
 
 
 func _on_resume_pressed() -> void:
-		is_paused = false
-		get_tree().paused = false
-		hide()
+	is_paused = false
+	get_tree().paused = false
+	hide()
 
 func _on_locker_pressed() -> void:
-		#Load Meat Locker
-		var meat_locker_scene := load("res://menu/skill_tree/skill_tree.tscn")
-		add_child(meat_locker_scene.instantiate())
+	#Load Meat Locker
+	var meat_locker_scene := load("res://menu/skill_tree/skill_tree.tscn")
+	add_child(meat_locker_scene.instantiate())
 
 func _on_settings_pressed() -> void:
-		var options_scene := load("res://menu/options_menu/options_menu.tscn")
-		add_child(options_scene.instantiate())
+	var options_scene := load("res://menu/options_menu/options_menu.tscn")
+	add_child(options_scene.instantiate())
 
 func _on_restart_pressed() -> void:
-		print("Restart to last campfire")
+	Save.load_game()
 
 func _on_menu_pressed() -> void:
-		get_tree().change_scene_to_file("res://menu/main_menu/main_menu.tscn")
+	get_tree().change_scene_to_file("res://menu/main_menu/main_menu.tscn")
 
 func _exit_tree() -> void: 
 	get_tree().paused = false


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #585 - Can't reload save from in game menu

**Summarize what's new, especially anything not mentioned in the issue.**
The "Load save" button in the pause menu now reloads the game from the last campfire spot.

**If there's any remaining work needed, describe that here.**
N/A

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Play the game and save at a different campfire. Move somewhere else, pause the game, and then load the save. The game should return to the save point.