### PR TITLE
Escape key closes submenus when paused

### DIFF
--- a/menu/pause_menu/pause_menu.gd
+++ b/menu/pause_menu/pause_menu.gd
@@ -1,6 +1,9 @@
 extends Control
 var is_paused: bool = false
 
+## A reference to any menu that is instantiated by the pause menu.
+var submenu : CanvasItem
+
 @export var resume_button: Button
 @export var locker_button: Button
 @export var settings_button: Button
@@ -22,13 +25,14 @@ func _process(_delta: float) -> void:
 	#Makes ESC key toggle pause menu visibility
 	if(Input.is_action_just_pressed("ui_cancel")):
 		print("PAUSED")
-		match is_paused:
-			true:
-				_on_resume_pressed()
-			false:
-				get_tree().paused = true
-				is_paused = true
-				show()
+		if is_paused and submenu and submenu.visible:
+			submenu.queue_free()
+		elif is_paused:
+			_on_resume_pressed()
+		else:
+			get_tree().paused = true
+			is_paused = true
+			show()
 
 
 func _on_resume_pressed() -> void:
@@ -39,11 +43,13 @@ func _on_resume_pressed() -> void:
 func _on_locker_pressed() -> void:
 		#Load Meat Locker
 		var meat_locker_scene := load("res://menu/skill_tree/skill_tree.tscn")
-		add_child(meat_locker_scene.instantiate())
+		submenu = meat_locker_scene.instantiate()
+		add_child(submenu)
 
 func _on_settings_pressed() -> void:
 		var options_scene := load("res://menu/options_menu/options_menu.tscn")
-		add_child(options_scene.instantiate())
+		submenu = options_scene.instantiate()
+		add_child(submenu)
 
 func _on_restart_pressed() -> void:
 		print("Restart to last campfire")

--- a/menu/pause_menu/pause_menu.tscn
+++ b/menu/pause_menu/pause_menu.tscn
@@ -22,6 +22,7 @@ font_size = 66
 
 [node name="PauseMenu" type="Control" node_paths=PackedStringArray("resume_button", "locker_button", "settings_button", "restart_button", "menu_button")]
 process_mode = 3
+process_priority = -1
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/menu/skill_tree/skill_tree.gd
+++ b/menu/skill_tree/skill_tree.gd
@@ -20,6 +20,11 @@ func _ready() -> void:
 	##This has to happen after all the purchase states are set
 	update_state()
 
+func _process(_delta: float) -> void:
+	if Input.is_action_just_pressed("ui_cancel"):
+		_on_exit_button_pressed()
+	
+
 func on_skill_pressed(skill_button : Skill_Button) -> void:
 	if selected_skill_button != null:
 		return


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #489 - Escape should close skill tree menu

**Summarize what's new, especially anything not mentioned in the issue.**
Pressing the ESC key closes the skill tree and settings menu, returning to the pause menu.

**If there's any remaining work needed, describe that here.**
Escape does _not_ close the skill tree menu when it is accessed from the campfire menu.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Play the game, then pause the game and open the skill tree. Press escape to return, then open settings. Press escape twice to resume.