### PR TITLE
Hooks encounters into the existing transition system

### DIFF
--- a/systems/scene_switch/scene_switch.gd
+++ b/systems/scene_switch/scene_switch.gd
@@ -5,7 +5,9 @@ extends CanvasLayer
 
 var transition_time : float = -1
 var switched_scenes : bool
-var next_scene : String
+var next_scene : PackedScene
+
+var quit : bool
 
 func in_transition() -> bool:
 	return transition_time >= 0
@@ -13,14 +15,22 @@ func in_transition() -> bool:
 func change_scene_to_file(file_path : String, pause_scene : bool = false) -> void:
 	transition_time = 0
 	switched_scenes = false
-	next_scene = file_path
+	next_scene = load(file_path)
+	$ColorRect.show()
+	get_tree().paused = pause_scene
+
+func change_scene_to_packed(scene : PackedScene, pause_scene : bool = false) -> void:
+	transition_time = 0
+	switched_scenes = false
+	next_scene = scene
 	$ColorRect.show()
 	get_tree().paused = pause_scene
 
 func quit_game() -> void:
 	transition_time = 0
 	switched_scenes = false
-	next_scene = "quit"
+	next_scene = null
+	quit = true
 	$ColorRect.show()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -29,10 +39,10 @@ func _process(delta: float) -> void:
 		transition_time += delta
 		$ColorRect.color.a = fade_curve.sample(clampf(transition_time,fade_curve.min_domain,fade_curve.max_domain))
 		if not switched_scenes and transition_time >= scene_change_time:
-			if next_scene == "quit":
+			if quit:
 				get_tree().quit()
 			else:
-				get_tree().change_scene_to_file(next_scene)
+				get_tree().change_scene_to_packed(next_scene)
 		if transition_time >= fade_curve.max_domain:
 			$ColorRect.hide()
 			transition_time = -1

--- a/world/enemy/encounter/encounter.gd
+++ b/world/enemy/encounter/encounter.gd
@@ -99,7 +99,7 @@ func end_encounter() -> void:
 		obj.finish()
 	
 	if ending_scene != null:
-		get_tree().change_scene_to_packed(ending_scene)
+		SceneManager.change_scene_to_packed(ending_scene)
 
 func _is_encounter_done() -> bool:
 	for o: EncounterObject in get_encounter_objects():


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #620 

**Summarize what's new, especially anything not mentioned in the issue.**
Makes encounters use the new transition system instead of godot's built in one

**If there's any remaining work needed, describe that here.**
Check that other scripts use the new transition system so they can fade in/out

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Try killing the enemies in level_town_v1 and see if it fades out