### PR TITLE
Preventing gain of control while in campfire menu via rolling

### DIFF
--- a/world/player/player.gd
+++ b/world/player/player.gd
@@ -213,9 +213,10 @@ func can_shoot() -> bool:
 
 ## Begins the roll by changing the state and decreasing stamina.
 func begin_roll() -> void:
+	#REDUNDANT
 	# This function only runs when the roll starts.
 	# Get out of here if you're already rolling!
-	if current_state == PlayerState.ROLLING: return
+	#if current_state == PlayerState.ROLLING: return
 	
 	# Factor in stamina
 	if stamina < 1.0: return


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #648 

**Summarize what's new, especially anything not mentioned in the issue.**
In player.gd, under physics_process, the player can now only roll from the WALKING state, and not while rolling or at the campfire.

**If there's any remaining work needed, describe that here.**
There is some code that's marked as redundant (checked for the rolling state before starting a roll, but the new order of physics_process now means that is not possible. Maybe...) so ensure that the player truly cannot roll while rolling.

Also, I could not open the pause menu while in the campfire menu. I may be missing how to replicate this issue, or was this fixed?

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Go up to a campfire, enter that menu, and try to roll.