### PR TITLE
Fixed bullet lifetimes expiring while game is paused

### DIFF
--- a/world/bullets/bullet.gd
+++ b/world/bullets/bullet.gd
@@ -18,7 +18,6 @@ var velocity: Vector3
 func _ready() -> void:
 	# Immediately set the despawn timer and wait
 	await get_tree().create_timer(despawn_after_seconds, false).timeout
-	print("all done")
 	queue_free()
 
 ## Creates the bullet.


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #656

**Summarize what's new, especially anything not mentioned in the issue.**
Added false argument to bullet.gd's timer in _ready(): away get_tree().create_timer(despawn_after_seconds, **false**).timeout. Now, this timer will pause whenever the scene tree (the game) is paused, and will resume when the game is resumed.

**If there's any remaining work needed, describe that here.**
Not sure, already checked that bullet's despawn properly after pausing. Perhaps just double-check that the timing of the bullet being freed lines up with what is in the script.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Shoot a bullet (or have an enemy, like a bandit, shoot a bullet) and pause the game. It should not despawn. You can also test the bullet despawning after unpausing; I used a print statement after the away in _ready() to see that this happened.
