### PR TITLE
Level mines matthew

### DIFF
--- a/world/levels/mines/level_mines.tscn
+++ b/world/levels/mines/level_mines.tscn
@@ -383,72 +383,69 @@ transform = Transform3D(8.173421, 0, 0, 0, 1, 0, 0, 0, 1.7462521, -11.476883, 0.
 transform = Transform3D(1.782, 0, 0, 0, 1, 0, 0, 0, 4.257, 11.192894, 1.0016572, 1.5294132)
 
 [node name="Wilder2" parent="Encounter4" index="4" instance=ExtResource("6_fb8xb")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.0305176, 0.74387836, -7.890179)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.1367188, 0.74387836, -6.195484)
 
-[node name="LonghornEnemy3" parent="Encounter4" index="5" instance=ExtResource("5_ci4pn")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.1104126, 1.7349594, 5.1060734)
-
-[node name="Puddle" parent="Encounter4" index="6" instance=ExtResource("12_akuqq")]
+[node name="Puddle" parent="Encounter4" index="5" instance=ExtResource("12_akuqq")]
 transform = Transform3D(-4.685498e-08, 0, 1, 0, 1, 0, -1.0719169, 0, -4.371139e-08, -9.09996, 0.73471504, -2.7579918)
 
-[node name="Puddle2" parent="Encounter4" index="7" instance=ExtResource("12_akuqq")]
+[node name="Puddle2" parent="Encounter4" index="6" instance=ExtResource("12_akuqq")]
 transform = Transform3D(1.0688308, 0, 0, 0, 1, 0, 0, 0, 1, 4.099434, 0.7442365, 6.604368)
 
-[node name="Puddle3" parent="Encounter4" index="8" instance=ExtResource("12_akuqq")]
+[node name="Puddle3" parent="Encounter4" index="7" instance=ExtResource("12_akuqq")]
 transform = Transform3D(-0.9182749, 0, -8.742278e-08, 0, 1, 0, 8.027814e-08, 0, -1, 3.178543, 0.7349592, -1.913846)
 
-[node name="Boulder" parent="Encounter4" index="9" instance=ExtResource("12_rkdtq")]
+[node name="Boulder" parent="Encounter4" index="8" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.4287415, 0.913001, -0.39137363)
 
-[node name="Boulder2" parent="Encounter4" index="10" instance=ExtResource("12_rkdtq")]
+[node name="Boulder2" parent="Encounter4" index="9" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(0.84526193, 0, 0, 0, 1, 0, 0, 0, 1, 0.51114655, 0.9130047, -0.30974007)
 
-[node name="Boulder3" parent="Encounter4" index="11" instance=ExtResource("12_rkdtq")]
+[node name="Boulder3" parent="Encounter4" index="10" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.3522263, 0.9129991, -0.24603081)
 
-[node name="Boulder4" parent="Encounter4" index="12" instance=ExtResource("12_rkdtq")]
+[node name="Boulder4" parent="Encounter4" index="11" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(0.92635876, 0, 0, 0, 1, 0, 0, 0, 1, -1.9534836, 0.9130066, 0.2514515)
 
-[node name="Boulder5" parent="Encounter4" index="13" instance=ExtResource("12_rkdtq")]
+[node name="Boulder5" parent="Encounter4" index="12" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(0.8781248, 0, 0, 0, 0.9845773, 0, 0, 0, 1, -1.0014038, 0.9130028, 1.0047207)
 
-[node name="Boulder6" parent="Encounter4" index="14" instance=ExtResource("12_rkdtq")]
+[node name="Boulder6" parent="Encounter4" index="13" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(1.0808668, 0, 0, 0, 1.0864774, 0, 0, 0, 1, 0.45837402, 0.91300666, 1.2170258)
 
-[node name="Boulder7" parent="Encounter4" index="15" instance=ExtResource("12_rkdtq")]
+[node name="Boulder7" parent="Encounter4" index="14" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(0.80135465, 0, 0, 0, 0.88426274, 0, 0, 0, 1, 1.641922, 0.9130029, 1.1956253)
 
-[node name="Boulder8" parent="Encounter4" index="16" instance=ExtResource("12_rkdtq")]
+[node name="Boulder8" parent="Encounter4" index="15" instance=ExtResource("12_rkdtq")]
 transform = Transform3D(0.9712043, 0, 0, 0, 1.1432368, 0, 0, 0, 1, 2.3041153, 0.7273741, 0.7510433)
 
-[node name="EnemyTest" parent="Encounter4" index="17" instance=ExtResource("16_lrsis")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.900719, 0.7348391, 4.252573)
+[node name="EnemyTest" parent="Encounter4" index="16" instance=ExtResource("16_lrsis")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.498802, 0.7348391, 3.9524364)
 
-[node name="EnemyTest2" parent="Encounter4" index="18" instance=ExtResource("16_lrsis")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.522194, 0.7348391, 9.609056)
+[node name="EnemyTest2" parent="Encounter4" index="17" instance=ExtResource("16_lrsis")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.7698517, 0.7348391, 10.544849)
 
-[node name="EnemyTest3" parent="Encounter4" index="19" instance=ExtResource("16_lrsis")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.30047607, 0.7348391, 7.3496265)
+[node name="EnemyTest3" parent="Encounter4" index="18" instance=ExtResource("16_lrsis")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.9128418, 0.7348391, 6.955845)
 
-[node name="EnemyTest4" parent="Encounter4" index="20" instance=ExtResource("16_lrsis")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.9905624, 0.7348391, 1.4285316)
+[node name="EnemyTest4" parent="Encounter4" index="19" instance=ExtResource("16_lrsis")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.0457535, 0.73484004, 2.6869106)
 
-[node name="JudgeEnemy" parent="Encounter4" index="21" instance=ExtResource("16_skfgv")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.7332153, 0.7348372, 4.111723)
+[node name="JudgeEnemy" parent="Encounter4" index="20" instance=ExtResource("16_skfgv")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.4852219, 0.7348381, 4.0933475)
 
-[node name="JudgeEnemy2" parent="Encounter4" index="22" instance=ExtResource("16_skfgv")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.6226273, 0.7348372, -2.5395432)
+[node name="JudgeEnemy2" parent="Encounter4" index="21" instance=ExtResource("16_skfgv")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.8985214, 0.7348372, -2.1712513)
 
-[node name="BirdSwarm" parent="Encounter4" index="23" instance=ExtResource("31_rewlr")]
+[node name="BirdSwarm" parent="Encounter4" index="22" instance=ExtResource("31_rewlr")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.1034927, 0.95692855, -6.4356766)
 
-[node name="BirdSwarm2" parent="Encounter4" index="24" instance=ExtResource("31_rewlr")]
+[node name="BirdSwarm2" parent="Encounter4" index="23" instance=ExtResource("31_rewlr")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.4046173, 0.95692855, -6.4356766)
 
-[node name="BirdSwarm3" parent="Encounter4" index="25" instance=ExtResource("31_rewlr")]
+[node name="BirdSwarm3" parent="Encounter4" index="24" instance=ExtResource("31_rewlr")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.2499313, 0.95692855, -0.5187321)
 
-[node name="BirdSwarm4" parent="Encounter4" index="26" instance=ExtResource("31_rewlr")]
+[node name="BirdSwarm4" parent="Encounter4" index="25" instance=ExtResource("31_rewlr")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.8133163, 0.95692855, 4.8024025)
 
 [node name="Encounter5" parent="." index="14" instance=ExtResource("11_rkdtq")]


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes #
Ammo box in encounter 3 is no longer a child of a bolder so it shouldn't randomly disappear when a bolder is destroyed.

made encounter 3 a bit larger so you cannot walk past and skip it.

**Summarize what's new, especially anything not mentioned in the issue.**
Added Decoration to the entirety of the mines level, scaled up the difficulty for both encounter 3 and 4, added temporary comments noting where the NPC and notes should go in the mines level. 

**If there's any remaining work needed, describe that here.**
...

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
...