### PR TITLE
Options Menu Fixes

### DIFF
--- a/menu/main_menu/main_menu.gd
+++ b/menu/main_menu/main_menu.gd
@@ -35,8 +35,11 @@ func _on_options_button_pressed() -> void:
 	
 	var options: Control = load("res://menu/options_menu/options_menu.tscn").instantiate()
 	add_child(options)
-	await options.tree_exiting # options menus frees itself when closed
-	button_pressed = false
+	await options.tree_exiting.connect(func() -> void:
+		%SettingsButton.button_pressed = false
+		button_pressed = false
+	) # options menus frees itself when closed
+	
 
 func _on_quit_button_pressed() -> void:
 	if not button_pressed:

--- a/menu/main_menu/main_menu.tscn
+++ b/menu/main_menu/main_menu.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="AudioStream" uid="uid://dc6lbunkflvv4" path="res://audio/placeholders/funny_bone_man.wav" id="4_prid6"]
 [ext_resource type="Texture2D" uid="uid://couuwyoltb6ql" path="res://menu/main_menu/main_menu_bg.png" id="5_rp3yq"]
 [ext_resource type="Texture2D" uid="uid://pfati0vufsd7" path="res://menu/main_menu/main_menu_player.png" id="6_c0jbr"]
-[ext_resource type="Script" path="res://menu/main_menu/reticle_spin.gd" id="7_dn5jd"]
+[ext_resource type="Script" uid="uid://co66s5c2pttrb" path="res://menu/main_menu/reticle_spin.gd" id="7_dn5jd"]
 [ext_resource type="Texture2D" uid="uid://d3fmltuim8c47" path="res://menu/main_menu/menu_player_eye.png" id="7_mij2p"]
 [ext_resource type="Texture2D" uid="uid://k38kdp8yrqo2" path="res://menu/main_menu/main_logo.png" id="8_mij2p"]
 [ext_resource type="Texture2D" uid="uid://veqmqpjiki0d" path="res://world/player/reticle/reticle.png" id="9_mij2p"]

--- a/menu/options_menu/options_menu.gd
+++ b/menu/options_menu/options_menu.gd
@@ -1,12 +1,21 @@
+class_name Options
 extends Control
+
+static var sfx_value : float = 100:
+	set(new_val):
+		sfx_value = new_val
+		AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("SFX"), new_val / 100.0)
+	
+static var music_value :float = 100:
+	set(new_val):
+		music_value = new_val
+		MainMusicPlayer.set_master_loudness(clampf(new_val / 100.0, 0.0, 1.0))
+
 @export var back_button : Button
 
 @onready var music_bus := AudioServer.get_bus_index("Music")
 @onready var sfx_bus := AudioServer.get_bus_index("SFX")
 
-# Volumes from 0 to 100
-@onready var sfx_value := db_to_linear(AudioServer.get_bus_volume_db(sfx_bus)) * 100
-@onready var music_value := MainMusicPlayer.get_master_loudness() * 100.0
 
 func _ready() -> void:
 	open()

--- a/menu/options_menu/options_menu.tscn
+++ b/menu/options_menu/options_menu.tscn
@@ -162,6 +162,7 @@ offset_left = 147.0
 offset_top = 103.0
 offset_right = 452.0
 offset_bottom = 170.0
+step = 5.0
 
 [node name="SFX" type="HSlider" parent="Sign/Control"]
 unique_name_in_owner = true
@@ -170,6 +171,7 @@ offset_left = 147.0
 offset_top = 174.0
 offset_right = 446.0
 offset_bottom = 194.0
+step = 5.0
 
 [node name="MusicPercentage" type="Label" parent="Sign/Control"]
 unique_name_in_owner = true

--- a/systems/save/options_save.gd
+++ b/systems/save/options_save.gd
@@ -16,12 +16,13 @@ static func load_options() -> void:
 		options_save_data = ResourceLoader.load(OPTIONS_SAVE)
 	else:
 		options_save_data = OptionsSave.new()
-		
-	MainMusicPlayer.set_master_loudness(clampf(options_save_data.music_value / 100.0, 0.0, 1.0))
-	AudioServer.set_bus_volume_linear(sfx_bus, options_save_data.sfx_value / 100.0)
+	
+	Options.sfx_value = options_save_data.music_value
+	Options.music_value = options_save_data.sfx_value
 	
 static func save_options() -> void:
-	options_save_data.sfx_value = db_to_linear(AudioServer.get_bus_volume_db(sfx_bus)) * 100
-	options_save_data.music_value = MainMusicPlayer.get_master_loudness() * 100.0
+	print()
+	options_save_data.sfx_value = Options.sfx_value
+	options_save_data.music_value = Options.music_value
 	ResourceSaver.save(options_save_data, OPTIONS_SAVE)
 	


### PR DESCRIPTION
**Summarize what's new, especially anything not mentioned in the issue.**
- Clamps the options sliders to 5%
- Reworked how sfx & music volume is stored to allow the player to set music to 0%
- restores the bullet hole when exiting the options menu