### PR TITLE
Set transform for WilderShootSound node to reduce volume

### DIFF
--- a/world/enemy/tutorial_turret/tutorial_turret.tscn
+++ b/world/enemy/tutorial_turret/tutorial_turret.tscn
@@ -59,6 +59,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.70077324, 1.3351865, 0)
 [node name="WilderDeathSound" parent="." instance=ExtResource("7_0jggp")]
 
 [node name="WilderShootSound" parent="." instance=ExtResource("8_h6ti2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11.399173, 0)
 volume_db = -6.0
 max_db = 0.0
 


### PR DESCRIPTION
Added a specific Transform3D value to the WilderShootSound node in the tutorial_turret scene to define its position. This should reduce the turrets' volume

**What issue does this close? For multiple, write a line for each.**
N/A