### PR TITLE
Adjust amplify_db for boss and sheriff theme songs

### DIFF
--- a/audio/music/song_files/desert_level/Nathan_horse_boss_song.tres
+++ b/audio/music/song_files/desert_level/Nathan_horse_boss_song.tres
@@ -24,3 +24,4 @@ fade_out_curve = SubResource("Curve_tuqa8")
 script = ExtResource("1_0hhjs")
 song_file = ExtResource("3_tuqa8")
 sections = Array[ExtResource("2_lmix2")]([SubResource("Resource_3ii8u")])
+amplify_db = -4.0

--- a/audio/music/song_files/town_level_corrupted/RA_Sheriff_Theme.tres
+++ b/audio/music/song_files/town_level_corrupted/RA_Sheriff_Theme.tres
@@ -25,4 +25,4 @@ fade_out_curve = SubResource("Curve_dj2bl")
 script = ExtResource("1_8fncy")
 song_file = ExtResource("3_301if")
 sections = Array[ExtResource("2_rc8fg")]([SubResource("Resource_kaqgc")])
-amplify_db = -0.10000000000000142
+amplify_db = -4.0


### PR DESCRIPTION
Set the amplify_db property to -4.0 for both 'Nathan_horse_boss_song.tres' and 'RA_Sheriff_Theme.tres' to lower boss song volume.

**What issue does this close? For multiple, write a line for each.**
N/A