### PR TITLE
Skill tree fix

### DIFF
--- a/audio/music/song_files/town_level_corrupted/RA_Sheriff_Theme.tres
+++ b/audio/music/song_files/town_level_corrupted/RA_Sheriff_Theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="Song" load_steps=7 format=3 uid="uid://becxyi6a0wlmk"]
+[gd_resource type="Resource" script_class="Song" load_steps=7 format=3 uid="uid://dqxmtv0owgod4"]
 
 [ext_resource type="Script" uid="uid://co2r0p266y1vu" path="res://audio/music/song_resource/song.gd" id="1_8fncy"]
 [ext_resource type="Script" uid="uid://b7okmeqcdjwec" path="res://audio/music/song_resource/section.gd" id="2_rc8fg"]

--- a/menu/skill_tree/skill_button.gd
+++ b/menu/skill_tree/skill_button.gd
@@ -119,8 +119,8 @@ func update_state() -> void:
 	if dependencies.has(unbought) and bought != null:
 		unbought.state = State.LOCKED
 		print("unbought: " + str(unbought))
-		dependencies.erase(unbought)
-		evil_dependencies.append(unbought)
+		#dependencies.erase(unbought)
+		#evil_dependencies.append(unbought)
 	
 	#for dependency : Skill_Button in dependencies:
 	#if dependency.state != State.PURCHASED:
@@ -168,9 +168,12 @@ func purchase() -> void:
 	$TextureRect.texture = itemDesc.skill_image_upgraded
 	%PurchaseParticles.emitting = true
 	
-	for child in evil_dependencies:
-		if child.state == State.LOCKED:
-				child.remove(Line2D)
+	#for child in dependencies:
+	#	if child.state != State.PURCHASED:
+	#		var line := self.get_node("Line2D")
+	#		print("line" + str(line))
+	#		if line != null:
+	#			line.queue_free()
 	
 	# Dialogue
 	play_dialogue()

--- a/menu/skill_tree/skill_button.gd
+++ b/menu/skill_tree/skill_button.gd
@@ -63,13 +63,21 @@ func _ready() -> void:
 	
 	# Fix this, make sure line goes in correct place
 	for child in dependencies:
-		if child.state != State.LOCKED:
+		if child.state != State.LOCKED or child.state == State.PURCHASED:
 			var line := Line2D.new()
 			line.texture = preload("res://menu/skill_tree/skill_tree_icons/board_connector.png")
 			line.texture_mode = Line2D.LINE_TEXTURE_STRETCH
 			line.add_point(Vector2.ZERO)
 			line.add_point(child.global_position - self.global_position)
 			%SkillBranches.add_child(line)
+			if child.state == State.PURCHASED:
+				# Draws meat on every other button
+				$TextureRect.texture = itemDesc.skill_image_upgraded
+	
+	# Draws on base button
+	if dependencies.size() == 0 and state == State.PURCHASED:
+		$TextureRect.texture = itemDesc.skill_image_upgraded
+		
 
 func update_purchase_state() -> void:
 	if SkillSet.has_skill(itemDesc.skill_uid):
@@ -156,8 +164,13 @@ func purchase() -> void:
 	purchase_made.emit(itemDesc.skill_uid)
 	
 	# Visuals
+	# Here is the meat texture
 	$TextureRect.texture = itemDesc.skill_image_upgraded
 	%PurchaseParticles.emitting = true
+	
+	for child in evil_dependencies:
+		if child.state == State.LOCKED:
+				child.remove(Line2D)
 	
 	# Dialogue
 	play_dialogue()

--- a/menu/skill_tree/skill_tree.gd
+++ b/menu/skill_tree/skill_tree.gd
@@ -45,8 +45,9 @@ func on_skill_pressed(skill_button : Skill_Button) -> void:
 	tween.tween_property(self,"scale",Vector2(zoom_strength,zoom_strength),zoom_time)
 	tween.tween_property(self,"position",-zoom_strength*(skill_button.global_position+zoom_offset),zoom_time)
 	
-	#for skill_button : Skill_Button in skill_buttons:
-		#skill_button.update_state()
+	# I uncommented this, I think it's fine for now
+	for button : Skill_Button in skill_buttons:
+		button.update_state()
 
 
 func _on_purchase_pressed() -> void:


### PR DESCRIPTION
**What issue does this close? For multiple, write a line for each.**
Closes an issue with skill tree.

**Summarize what's new, especially anything not mentioned in the issue.**
When you reopen the skill tree, purchased skills are now meat textures.

**If there's any remaining work needed, describe that here.**
I still can't figure out how to get rid of the extra line from the unbought skill to the new skill.

**How should this be tested? Include what scene it's in, and any steps to test every feature.**
Go to any campfire and buy some skills. You close it and reopen it to see it again.